### PR TITLE
Python3 support

### DIFF
--- a/ftrace
+++ b/ftrace
@@ -34,6 +34,7 @@
 
 """
 
+from __future__ import print_function
 import sys
 import os
 import subprocess as sub
@@ -903,15 +904,15 @@ def dump_stacks_as_text(stackdumps, fd=sys.stdout):
         for d_num, d_stk in dumped_stacks:
             if stk == d_stk:
                 is_dupe = True
-                print( "(Stackdump %d is a duplicate of %d, not dumping)" % (num, d_num))
+                print( "(Stackdump %d is a duplicate of %d, not dumping)" % (num, d_num), file=fd)
                 break
 
         if not is_dupe:
             indent = 1
             dumped_stacks.appendleft( (num, stk) )
-            print( "Stackdump %d:" % num )
+            print( "Stackdump %d:" % num, file=fd)
             for frame in stk:
-                print( "\t"*indent + str(frame))
+                print( "\t"*indent + str(frame), file=fd)
                 indent += 1
                 
 

--- a/ftrace
+++ b/ftrace
@@ -386,19 +386,19 @@ class Frame(object):
         # parentheses in the arguments, so we have to ensure that the argument
         # list remains intact. We do this by assuming that the first '(' is
         # the start of the argument list, and the last ')' is the end.
-        bits = self.function.split('(')
+        bits = self.function.split(b'(')
         name = bits[0].strip()                          # Function name
-        bits = '('.join(bits[1:]).strip().split(')')
-        args = ')'.join(bits[:-1])                      # Argument list            
+        bits = b'('.join(bits[1:]).strip().split(b')')
+        args = b')'.join(bits[:-1])                      # Argument list            
 
         # The last frame in a stack gets the line-number off by one:
         adj = 1 if self.number==0 else 0
 
         d = {
-            'name'   : name,
-            'args'   : args,
+            'name'   : name.decode("utf-8"),
+            'args'   : args.decode("utf-8"),
             'frameno': str(self.number),
-            'file'   : '' if self.sourceFile is None else self.sourceFile,
+            'file'   : '' if self.sourceFile is None else self.sourceFile.decode("utf-8"),
             'address': '' if self.address is None else '0x%x' % self.address,
             'prefix' : '' if Frame._prefix is None else Frame._prefix,
             'lineno' : '' if self.lineNumber is None else str(self.lineNumber-adj)

--- a/ftrace
+++ b/ftrace
@@ -249,6 +249,9 @@ def parse_command_line():
             help='optional PROG arguments')
 
     OPT = CLAP.parse_args()
+
+    if which('dot') is None:
+        setattr(OPT, "dot", False)
     
     if OPT.url is not None:
         if OPT.html or OPT.dot:

--- a/ftrace
+++ b/ftrace
@@ -949,8 +949,8 @@ def dump_stacks_as_dot(stackdumps, fd=sys.stdout):
 
     for (src,dst),nodes in edges.items():
         for (nr,td) in nodes.items():
-            td['src']=src
-            td['dst']=dst
+            td['src']=src.decode("utf-8")
+            td['dst']=dst.decode("utf-8")
             print(nr,td)
             fd.write('    ' + tmpl % td + '\n')
     fd.write('}\n')

--- a/ftrace
+++ b/ftrace
@@ -575,10 +575,8 @@ def gdb_chat(bp_queue):
     stkRe = re.compile(r'^#\d+[ ]+')
     # Line produced when the program-under-test exits normally:
     endRe = re.compile(r'^\[Inferior \d+ \(process \d+\) exited')
-    # Line produced when GDB sets a breakpoint:
-    bptRe = re.compile(r'^(?:Breakpoint (\d+) at 0x([0-9a-f]{6,}))(?:: file ([^,]+), line ([0-9]+)\.)?$')
-    # Subprompt noise from setting breakpoints:
-    spnRe = re.compile(r'^>+\(gdb\) |>+$')
+    # Line produced when GDB sets a breakpoint (might be preceded by subprompt/prompt noise):
+    bptRe = re.compile(r'(?:Breakpoint (\d+) at 0x([0-9a-f]{6,}))(?:: file ([^,]+), line ([0-9]+)\.)?$')
 
     #|Note: breakpoint \d+ also set at')
     # Lines produced when GDB reads symbols, etc:
@@ -640,9 +638,7 @@ def gdb_chat(bp_queue):
                     inbuf = ''
                     for line in lines:
                         dprint("    |%s|" % line)
-                        line=spnRe.sub('', line)
-                        dprint("    :%s:" % line)
-                        m = bptRe.match(line)
+                        m = bptRe.search(line)
                         if m:
                             if bp_in_flight is not None:
                                 n,a,filename,l, = m.groups()

--- a/ftrace
+++ b/ftrace
@@ -66,8 +66,8 @@ GDB_CMD = ['gdb', '-q']
 
 # GDB width/height settings:
 GDB_SETTINGS = collections.deque([
-    'set width ' + str(IO_BUFLEN-2),
-    'set height 0'])
+    b'set width ' + str(IO_BUFLEN-2).encode('utf-8'),
+    b'set height 0'])
 
 # GDB breakpoint setting command:
 GDB_BRKPT_CMD = """b *0x%x
@@ -315,20 +315,20 @@ class Frame(object):
         bits = frameText.split(None, 1)
         self.number = int(bits[0][1:])
 
-        bits=bits[1].split(' in ')
+        bits=bits[1].split(b' in ')
 
         if len(bits)==2:
             self.address = int(bits[0], 16)
-            bits=bits[1].split(' at ')
+            bits=bits[1].split(b' at ')
         else:
-            bits=bits[0].split(' at ')
+            bits=bits[0].split(b' at ')
 
         self.function = bits[0]
 
         if len(bits) == 2:
-            bits = bits[1].split(':')
+            bits = bits[1].split(b':')
             self.lineNumber = int(bits[-1])
-            self.sourceFile = ':'.join(bits[:-1])
+            self.sourceFile = b':'.join(bits[:-1])
             if Frame._strip is not None and \
                     len(self.sourceFile) > len(Frame._strip) and \
                     self.sourceFile[:len(Frame._strip)] == Frame._strip:
@@ -371,8 +371,8 @@ class Frame(object):
         return '|'.join((
             str(self.number),
             '?' if self.address is None else '0x%x' % self.address,
-            self.function,
-            '?' if self.sourceFile is None else self.sourceFile,
+            self.function.decode("utf-8"),
+            '?' if self.sourceFile is None else self.sourceFile.decode("utf-8"),
             '?' if self.lineNumber is None else str(self.lineNumber))) 
 
 
@@ -463,7 +463,7 @@ def get_local_symbols( progname ):
     cmd = list(READELF_CMD)
     cmd.append(fqp)
     try:
-        lines=sub.check_output(cmd).split('\n')
+        lines=sub.check_output(cmd).split(b'\n')
     except sub.CalledProcessError as cpe:
         die("Call to {} returned {}".format(cpe.cmd, cpe.returncode))
 
@@ -472,7 +472,7 @@ def get_local_symbols( progname ):
     for line in lines[3:]:
         fld = line.split()
         sz = len(fld)
-        if sz >= 8 and fld[3]=='FUNC' and int(fld[1],16)!=0 and int(fld[2])!=0: 
+        if sz >= 8 and fld[3]==b'FUNC' and int(fld[1],16)!=0 and int(fld[2])!=0: 
             symtuples.append( (fld[7], int(fld[1], 16)) )
         else:
             n_rejected += 1
@@ -556,7 +556,7 @@ def gdb_chat(bp_queue):
     backtraces = collections.deque()
     # We don't expect any output on stderr and we're not going to process it,
     # so don't bother with a deque:
-    errdata = ""
+    errdata = b''
 
 
     # Flags for various stages of interaction with GDB:
@@ -570,31 +570,31 @@ def gdb_chat(bp_queue):
 
     # Compiled regular expressions for different kinds of GDB output:
     # Prompt:
-    prmRe = re.compile(r'>*(\(gdb\) )+$')
+    prmRe = re.compile(b'>*(\(gdb\) )+$')
     # Backtrace lines:
-    stkRe = re.compile(r'^#\d+[ ]+')
+    stkRe = re.compile(b'^#\d+[ ]+')
     # Line produced when the program-under-test exits normally:
-    endRe = re.compile(r'^\[Inferior \d+ \(process \d+\) exited')
+    endRe = re.compile(b'^\[Inferior \d+ \(process \d+\) exited')
     # Line produced when GDB sets a breakpoint:
-    bptRe = re.compile(r'^(?:Breakpoint (\d+) at 0x([0-9a-f]{6,}))(?:: file ([^,]+), line ([0-9]+)\.)?$')
+    bptRe = re.compile(b'^(?:Breakpoint (\d+) at 0x([0-9a-f]{6,}))(?:: file ([^,]+), line ([0-9]+)\.)?$')
     # Subprompt noise from setting breakpoints:
-    spnRe = re.compile(r'^>+\(gdb\) |>+$')
+    spnRe = re.compile(b'^>+\(gdb\) |>+$')
 
     #|Note: breakpoint \d+ also set at')
     # Lines produced when GDB reads symbols, etc:
     infoLines = [
-        'Reading symbols from ',
-        'done.',
-        'Starting program: ',
-        'Using host lib',
-        '\[Thread debugging using libthread_db enabled\]',
+        b'Reading symbols from ',
+        b'done.',
+        b'Starting program: ',
+        b'Using host lib',
+        b'\[Thread debugging using libthread_db enabled\]',
         #    '>{1,4}(\(gdb\))?[ ]?',
-        'Note: breakpoint \d+ also set at pc 0x[0-9a-f]{6,}\.$'
+        b'Note: breakpoint \d+ also set at pc 0x[0-9a-f]{6,}\.$'
     ]
-    ackRe = re.compile( '|'.join(infoLines) )
+    ackRe = re.compile(b'|'.join(infoLines) )
 
     # Input buffer:
-    inbuf = ''
+    inbuf = b''
 
     # Breakpoint number:
     bpNum = 0
@@ -631,16 +631,17 @@ def gdb_chat(bp_queue):
 #                   dprint("[%s] '%i'" % (chunk, len(chunk)))
                     dprint("[%s]" % chunk)
                     inbuf += chunk
-                    if len(chunk)>0 and chunk[-1] != '\n' and len(chunk)>5 and chunk[-6:]!='(gdb) ':
+                    if len(chunk)>0 and chunk[-1] != b'\n' and len(chunk)>5 and chunk[-6:]!=b'(gdb) ':
                     # Not a complete line
+                        dprint("not a complete line")
                         continue
 
                     dprint("/%s/" % inbuf)
-                    lines = inbuf.split('\n')
-                    inbuf = ''
+                    lines = inbuf.split(b'\n')
+                    inbuf = b''
                     for line in lines:
                         dprint("    |%s|" % line)
-                        line=spnRe.sub('', line)
+                        line=spnRe.sub(b'', line)
                         dprint("    :%s:" % line)
                         m = bptRe.match(line)
                         if m:
@@ -710,7 +711,7 @@ def gdb_chat(bp_queue):
                         try:
                             setting = GDB_SETTINGS.popleft()
                             log("Sending setting '%s' to GDB" % setting)
-                            os.write( fo.fileno(), setting + "\n" )
+                            os.write( fo.fileno(), setting + b"\n" )
                             fo.flush()
                         except IndexError as ie:
                             die("Got index error trying to pop settings deque")
@@ -729,7 +730,8 @@ def gdb_chat(bp_queue):
                                 warn("Breakpoint number mismatch %d!=%d" % (bpNum, bp.number))
                             dprint("--- setting bp (%s)" % str(bp))
                             log("Setting breakpoint %d/%d: %s" % (bpNum,n_bps,str(bp)))
-                            os.write( fo.fileno(), GDB_BRKPT_CMD % bp.address )
+                            cmd = GDB_BRKPT_CMD % bp.address
+                            os.write( fo.fileno(),  cmd.encode('utf-8'))
                             fo.flush()
                             bp_in_flight = bp
                         except IndexError as ie:
@@ -743,15 +745,18 @@ def gdb_chat(bp_queue):
                                 cmd += ' '.join(OPT.ARGS) + ' '
                             cmd += '> ' + OPT.save_file
                             log("Sending '%s' to GDB" % cmd)
-                            os.write(fo.fileno(), cmd + '\n')
+                            cmd += '\n'
+                            os.write(fo.fileno(), cmd.encode('utf-8'))
                             fo.flush()
                             sentRun = True
                         except OSError as oe:
                             die("Got OSError writing 'run' to GDB's stdin")
                     elif gotExit and not done:
                         try:
-                            log("Sending 'quit' to GDB")
-                            os.write( fo.fileno(), "quit\n" )
+                            cmd = 'quit'
+                            log("Sending '%s' to GDB" % cmd)
+                            cmd += '\n'
+                            os.write( fo.fileno(),  cmd.encode('utf-8'))
                             fo.flush()
                             sentQuit = True
                         except OSError as oe:

--- a/ftrace
+++ b/ftrace
@@ -331,7 +331,7 @@ class Frame(object):
             self.sourceFile = b':'.join(bits[:-1])
             if Frame._strip is not None and \
                     len(self.sourceFile) > len(Frame._strip) and \
-                    self.sourceFile[:len(Frame._strip)] == Frame._strip:
+                    self.sourceFile[:len(Frame._strip)] == Frame._strip.encode("utf-8"):
                 self.sourceFile = self.sourceFile[len(Frame._strip):] 
     
 


### PR DESCRIPTION
Tweaks that  allow running with python3 while still staying compatible with python2.7 

The tweakage mainly consists of keeping strings in bytes rather than str where possible, with an occasional explicit conversion to str where str interpolation is used
